### PR TITLE
JavaFX runtime not found / OX X 10.7 / x64 / java 1.8

### DIFF
--- a/lib/jrubyfx/jfx_imports.rb
+++ b/lib/jrubyfx/jfx_imports.rb
@@ -31,7 +31,8 @@ begin
       jfx_path.gsub(/[\/\\][amdix345678_]+$/, "") # strip i386 or amd64 (including variants). TODO: ARM
     end
   end
-  require 'jfxrt.jar'
+	# Java 8 and above has JavaFX as part of the normal distib, only require it if we are 7 or below
+  require 'jfxrt.jar' if ENV_JAVA["java.runtime.version"].match(/^1\.[0-7]{1}\..*/)
 rescue  LoadError
   puts "JavaFX runtime not found.  Please install Java 7u6 or newer or set environment variable JFX_DIR to the folder that contains jfxrt.jar "
   puts "If you have Java 7u6 or later, this is a bug. Please report to the issue tracker on github. Include your OS version, 32/64bit, and architecture (x86, ARM, PPC, etc)"


### PR DESCRIPTION
Error:

``` bash
$ ruby samples/test_all_the_samples.rb 
================================================================================
 /Users/jeremy/Code/jrubyfx/samples/fxml/Demo.rb
================================================================================
JavaFX runtime not found.  Please install Java 7u6 or newer or set environment variable JFX_DIR to the folder that contains jfxrt.jar 
If you have Java 7u6 or later, this is a bug. Please report to the issue tracker on github. Include your OS version, 32/64bit, and architecture (x86, ARM, PPC, etc)
```

Sysinfo:

``` bash
$ java -version
java version "1.8.0-ea"
Java(TM) SE Runtime Environment (build 1.8.0-ea-b75)
Java HotSpot(TM) 64-Bit Server VM (build 25.0-b17, mixed mode)

$ ruby -v
jruby 1.7.2 (1.9.3p327) 2013-01-04 302c706 on Java HotSpot(TM) 64-Bit Server VM 1.8.0-ea-b75 +indy [darwin-x86_64]

$ uname -a
Darwin Jeremys-MBA.local 11.4.2 Darwin Kernel Version 11.4.2: Thu Aug 23 16:25:48 PDT 2012; root:xnu-1699.32.7~1/RELEASE_X86_64 x86_64
```

This Works:

``` bash
JFX_DIR=/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/jre/lib/ext ruby samples/test_all_the_samples.rb 
```
