### PR TITLE
fx_id variables in FXML JRubyFX::Controller#initialize

### DIFF
--- a/lib/jrubyfx/fxml_controller.rb
+++ b/lib/jrubyfx/fxml_controller.rb
@@ -213,7 +213,7 @@ class JRubyFX::Controller
   #
   def self.load_fxml(filename, stage, settings={})
     # Create our class as a java class with any arguments it wants
-    ctrl = self.new_java *(settings[:initialize] || [])
+    ctrl = self.new_java
     # save the stage so we can reference it if needed later
     ctrl.stage = stage
     # load the FXML file
@@ -226,6 +226,8 @@ class JRubyFX::Controller
     else
       Scene.new(parent, settings[:width] || -1, settings[:height] || -1, settings[:depth_buffer] || settings[:depthBuffer] || false)
     end
+
+    ctrl.ready *settings[:initialize].to_a if ctrl.respond_to? :ready
     # return the controller. If they want the new scene, they can call the scene() method on it
     return ctrl
   end

--- a/samples/fxml/Demo.rb
+++ b/samples/fxml/Demo.rb
@@ -51,10 +51,11 @@ class SimpleFXController < JRubyFX::Controller
   # if one controller will be used for multiple forms, use fx_id_optional 
   # instead of fx_id to avoid warnings that the id can't be found
   
-  # Initialize is optional
-  def initialize(first, second)
+  # Ready is optional
+  def ready(first, second)
     puts "Ruby new"
     puts "#{first} #{second}"
+    p @AnchorPane
   end
   
   # This is how events are defined in code.


### PR DESCRIPTION
I assumed that variables declared with `fx_id` would be available in `initialize`, but this does not appear to be so. Is this a bug, or should I setup objects elsewhere?

Same environment as #22 

``` ruby
# samples/fxml/Demo.rb

fx_id :AnchorPane
# …
def initialize(first, second)
  puts "Ruby new"
  puts "#{first} #{second}"
  p @AnchorPane # => nil
end
# …
fx_action_handler :clickbl do
  puts "Clicked Black"
  # This is the fx:id linked variable
  p @AnchorPane # => #<Java::JavafxSceneLayout::AnchorPane:0x62839dbf>
end
```
