### PR TITLE
"JavaFX runtime not found" — a Quality Solution

### DIFF
--- a/lib/jrubyfx/jfx_imports.rb
+++ b/lib/jrubyfx/jfx_imports.rb
@@ -31,10 +31,15 @@ begin
       jfx_path.gsub(/[\/\\][amdix345678_]+$/, "") # strip i386 or amd64 (including variants). TODO: ARM
     end
   end
-	# Java 8 (after b75) and above has JavaFX as part of the normal distib, only require it if we are 7 or below
-  jdk_version = ENV_JAVA["java.runtime.version"]
-  require 'jfxrt.jar' if ENV['JFX_DIR'] or jdk_version.match(/^1\.[0-7]{1}\..*/) or (jdk_version.match(/^1\.[8]{1}\..*/) and jdk_version.match(/-b(\d+)$/)[-1].to_i < 75)
-  testit = Java.javafx.application.Application
+
+  # Java 8 (after ea-b75) and above has JavaFX as part of the normal distib, only require it if we are 7 or below
+  jre = ENV_JAVA["java.runtime.version"].match %r{^(?<version>(?<major>\d+)\.(?<minor>\d+))\.(?<patch>\d+)(_\d+)?-?(?<release>ea|u\d)?(-?b(?<build>\d+))?}
+  require 'jfxrt.jar' if ENV['JFX_DIR'] or
+    jre[:version].to_f < 1.8 or
+    (jre[:version].to_f == 1.8 and jre[:release] == 'ea' and jre[:build].to_i < 75)
+
+  # Attempt to load a javafx class
+  Java.javafx.application.Application
 rescue  LoadError, NameError
   puts "JavaFX runtime not found.  Please install Java 7u6 or newer or set environment variable JFX_DIR to the folder that contains jfxrt.jar "
   puts "If you have Java 7u6 or later, this is a bug. Please report to the issue tracker on github. Include your OS version, 32/64bit, and architecture (x86, ARM, PPC, etc)"


### PR DESCRIPTION
Use a 1.9-style named regexp to correctly parse ENV_JAVA["java.runtime.version"]
I can write an equivalent 1.8-style regexp if necessary, but it would be less readable.

A few of the matches could be dropped, but leaving them in future-proofs the regexp.

See: http://rubular.com/r/UyWaY5qjIk

The current code will fail when java 8 is released (non-ea). `/-b(\d+)$/` would be nil, if no -bNN is present (nil.to_i is < 75). They also appear to reset their build count, when moving to a real release, eg -b04 would also match < 75. This proactively detects those conditions.

Parses:
1.8.0_10
1.8.0_10-u2-b23
1.8.0-ea-b75
1.7.0_10-ea-b07
1.8.0-ea-b63
1.6.0_33
1.6.0_31-b05
1.6.0_17-b04
1.7.0-u2-b21
1.7.0_13-b20
