### PR TITLE
fix duplicated slash in download url.

### DIFF
--- a/lib/jrubyfx_tasks.rb
+++ b/lib/jrubyfx_tasks.rb
@@ -26,7 +26,7 @@ module JRubyFX
   module Tasks
     extend Rake::DSL
     # Base URL of JRuby-complete.jar download location
-    BASE_URL='http://jruby.org.s3.amazonaws.com/downloads/'
+    BASE_URL='http://jruby.org.s3.amazonaws.com/downloads'
 
     ##
     # Downloads the jruby-complete jar file for `jruby_version` and save in
@@ -168,7 +168,7 @@ module JRubyFX
     private
     def download(version_string) #:nodoc:
       File.open("jruby-complete-#{version_string}.jar","wb") do |f|
-        f.write(open("#{BASE_URL}#{version_string}/jruby-complete-#{version_string}.jar").read)
+        f.write(open("#{BASE_URL}/#{version_string}/jruby-complete-#{version_string}.jar").read)
       end
     end
 


### PR DESCRIPTION
The generated download url for jruby-complete jar file contains duplicated slash like below.

`http://jruby.org.s3.amazonaws.com/downloads//1.7.12/jruby-complete-1.7.12.jar`

It causes following 404 error.

```
❯ jrubyfx-jarify samples/fxml --main samples/fxml/Demo.rb Demo.jar
mkdir -p /Users/momonga/.jruby-jar
cd /Users/momonga/.jruby-jar
JRuby complete jar not found. Downloading... (May take awhile)
OpenURI::HTTPError: 404 Not Found
open_http at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/1.9/open-uri.rb:346
buffer_open at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/1.9/open-uri.rb:775
open_loop at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/1.9/open-uri.rb:203
catch at org/jruby/RubyKernel.java:1264
open_loop at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/1.9/open-uri.rb:201
open_uri at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/1.9/open-uri.rb:146
open at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/1.9/open-uri.rb:677
open at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/1.9/open-uri.rb:33
download at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/gems/shared/gems/jrubyfx-1.1.0-java/lib/jrubyfx_tasks.rb:174
open at org/jruby/RubyIO.java:1182
download at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/gems/shared/gems/jrubyfx-1.1.0-java/lib/jrubyfx_tasks.rb:173
download_jruby at /Users/momonga/.rbenv/versions/jruby-1.7.12/lib/ruby/gems/shared/gems/jrubyfx-1.1.0-java/lib/jrubyfx_tasks.rb:44
(root) at /Users/momonga/.rbenv/versions/jruby-1.7.12/bin/jrubyfx-jarify:95
```

This commit fixes this problem.
