### PR TITLE
Add a sample that uses a Service instead of a Task

### DIFF
--- a/samples/contrib/concurrency_demos/service_demo.rb
+++ b/samples/contrib/concurrency_demos/service_demo.rb
@@ -53,20 +53,48 @@ class MyTask < javafx.concurrent.Task
   end
 end
 
-class ProgressBarDemo < JRubyFX::Application
-  def start(stage)
-    with(stage, title: "Progress Bar Demo with binded Task", width: 400,
-         height: 150) do
-      layout_scene do
-        progress_bar(id: 'bar')
+class MyService < javafx.concurrent.Service
+  def initialize(bar)
+    @bar = bar
+    super()
+  end
+
+  def createTask
+    MyTask.new.tap do |t|
+      t.set_on_cancelled do |event|
+        puts "task cancelled"
+      end
+
+      t.set_on_failed do |event|
+        puts "task failed #{event.to_s}: #{@bar.progress}"
       end
     end
-    my_task = MyTask.new
-    bar = stage['#bar']
-    bar.progress_property.bind(my_task.progress_property)
-    Java::java.lang.Thread.new(my_task).start
+  end
+end
 
+class ProgressBarWithServiceDemo < JRubyFX::Application
+  def start(stage)
+    with(stage, title: "Progress Bar Demo with binded Task", width: 200,
+         height: 100) do
+      layout_scene do
+        vbox(15, alignment: Java::javafx.geometry.Pos::CENTER) do
+          progress_bar(id: 'bar')
+          button("restart")
+        end
+      end
+    end
+
+    stage['.button'].set_on_action { restart_task }
+    bar = stage['#bar']
+    @my_service = MyService.new(bar)
+    bar.progress_property.bind(@my_service.progress_property)
+
+    @my_service.start
     stage.show
+  end
+
+  def restart_task
+    @my_service.restart
   end
 end
 

--- a/samples/contrib/concurrency_demos/service_demo.rb
+++ b/samples/contrib/concurrency_demos/service_demo.rb
@@ -54,11 +54,6 @@ class MyTask < javafx.concurrent.Task
 end
 
 class MyService < javafx.concurrent.Service
-  def initialize(bar)
-    @bar = bar
-    super()
-  end
-
   def createTask
     MyTask.new.tap do |t|
       t.set_on_cancelled do |event|
@@ -66,7 +61,7 @@ class MyService < javafx.concurrent.Service
       end
 
       t.set_on_failed do |event|
-        puts "task failed #{event.to_s}: #{@bar.progress}"
+        puts "task failed #{event.to_s}:"
       end
     end
   end
@@ -84,7 +79,7 @@ class ProgressBarWithServiceDemo < JRubyFX::Application
       end
     end
 
-    @my_service = MyService.new(bar)
+    @my_service = MyService.new
 
     bar = stage['#bar']
     bar.progress_property.bind(@my_service.progress_property)
@@ -95,4 +90,4 @@ class ProgressBarWithServiceDemo < JRubyFX::Application
   end
 end
 
-ProgressBarDemo.launch
+ProgressBarWithServiceDemo.launch

--- a/samples/contrib/concurrency_demos/service_demo.rb
+++ b/samples/contrib/concurrency_demos/service_demo.rb
@@ -84,17 +84,14 @@ class ProgressBarWithServiceDemo < JRubyFX::Application
       end
     end
 
-    stage['.button'].set_on_action { restart_task }
-    bar = stage['#bar']
     @my_service = MyService.new(bar)
+
+    bar = stage['#bar']
     bar.progress_property.bind(@my_service.progress_property)
+    stage['.button'].set_on_action { @my_service.restart }
 
     @my_service.start
     stage.show
-  end
-
-  def restart_task
-    @my_service.restart
   end
 end
 


### PR DESCRIPTION
Mostly the same thing as the Task sample app, just uses a restartable `Service` instead.