### PR TITLE
Quick fix for in_jar? / 9.1.3.0

### DIFF
--- a/lib/jrubyfx/application.rb
+++ b/lib/jrubyfx/application.rb
@@ -27,7 +27,7 @@ class JRubyFX::Application < Java.javafx.application.Application
   # and, if jruby changes, false negatives. If you are using this, it might be a
   # very bad idea... (though it is handy)
   def self.in_jar?()
-    $LOAD_PATH.inject(false) { |res,i| res || i.include?(".jar!/META-INF/jruby.home/lib/ruby/")}
+    $LOAD_PATH.inject(false) { |res,i| res || i.include?("/META-INF/jruby.home/lib/ruby/")}
   end
 
   ##


### PR DESCRIPTION
A quick fix to get `JRubyFX::Application.in_jar?` working with JRuby 9.1.3.0