### PR TITLE
JRubyFX Support Pre-Built OpenJFX Libraries 

### DIFF
--- a/lib/jrubyfx/part_imports.rb
+++ b/lib/jrubyfx/part_imports.rb
@@ -34,9 +34,19 @@ begin
 
   # Java 8 (after ea-b75) and above has JavaFX as part of the normal distib, only require it if we are 7 or below
   jre = ENV_JAVA["java.runtime.version"].match %r{^(?<version>(?<major>\d+)\.(?<minor>\d+))\.(?<patch>\d+)(_\d+)?-?(?<release>ea|u\d)?(-?b(?<build>\d+))?}
-  require 'jfxrt.jar' if ENV['JFX_DIR'] or
+  #require 'jfxrt.jar' if ENV['JFX_DIR'] or
+  #  jre[:version].to_f < 1.8 or
+  #  (jre[:version].to_f == 1.8 and jre[:release] == 'ea' and jre[:build].to_i < 75)
+  # add OpenJFX support if follow instruction from https://openjfx.io
+  if ENV['JFX_DIR'] or
     jre[:version].to_f < 1.8 or
     (jre[:version].to_f == 1.8 and jre[:release] == 'ea' and jre[:build].to_i < 75)
+    require 'jfxrt.jar'
+  elsif ENV['PATH_TO_FX'] # support the OpenJFX installation as in https://openjfx.io/openjfx-docs/#install-javafx as of 15th May 2020
+    Dir.glob(File.join(ENV['PATH_TO_FX'],"*.jar")).each do |jar|
+      require jar
+    end
+  end
 
   # Java 8 at some point requires explicit toolkit/platform initialization
   # before any controls can be loaded.
@@ -45,7 +55,9 @@ begin
   # Attempt to load a javafx class
   Java.javafx.application.Application
 rescue  LoadError, NameError
-  puts "JavaFX runtime not found.  Please install Java 7u6 or newer or set environment variable JFX_DIR to the folder that contains jfxrt.jar "
+  #puts "JavaFX runtime not found.  Please install Java 7u6 or newer or set environment variable JFX_DIR to the folder that contains jfxrt.jar "
+  # Advice user too about the OpenJFX support
+  puts "JavaFX runtime not found.  Please install Java 7u6 or newer, set environment variable JFX_DIR to the folder that contains jfxrt.jar or set the environment variable PATH_TO_FX that points to the OpenJFX libraries"
   puts "If you have Java 7u6 or later, this is a bug. Please report to the issue tracker on github. Include your OS version, 32/64bit, and architecture (x86, ARM, PPC, etc)"
   exit -1
 end

--- a/lib/jrubyfx/part_imports.rb
+++ b/lib/jrubyfx/part_imports.rb
@@ -34,9 +34,6 @@ begin
 
   # Java 8 (after ea-b75) and above has JavaFX as part of the normal distib, only require it if we are 7 or below
   jre = ENV_JAVA["java.runtime.version"].match %r{^(?<version>(?<major>\d+)\.(?<minor>\d+))\.(?<patch>\d+)(_\d+)?-?(?<release>ea|u\d)?(-?b(?<build>\d+))?}
-  #require 'jfxrt.jar' if ENV['JFX_DIR'] or
-  #  jre[:version].to_f < 1.8 or
-  #  (jre[:version].to_f == 1.8 and jre[:release] == 'ea' and jre[:build].to_i < 75)
   # add OpenJFX support if follow instruction from https://openjfx.io
   if ENV['JFX_DIR'] or
     jre[:version].to_f < 1.8 or
@@ -55,7 +52,6 @@ begin
   # Attempt to load a javafx class
   Java.javafx.application.Application
 rescue  LoadError, NameError
-  #puts "JavaFX runtime not found.  Please install Java 7u6 or newer or set environment variable JFX_DIR to the folder that contains jfxrt.jar "
   # Advice user too about the OpenJFX support
   puts "JavaFX runtime not found.  Please install Java 7u6 or newer, set environment variable JFX_DIR to the folder that contains jfxrt.jar or set the environment variable PATH_TO_FX that points to the OpenJFX libraries"
   puts "If you have Java 7u6 or later, this is a bug. Please report to the issue tracker on github. Include your OS version, 32/64bit, and architecture (x86, ARM, PPC, etc)"

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -4,45 +4,48 @@
 
 OpenJFX used was prebuilt library downloaded from [https://gluonhq.com/products/javafx/](https://gluonhq.com/products/javafx/) as that is referred by [https://openjfx.io](https://openjfx.io) download link.
 
+The patch is tested on two OSes:
+* Linux Mint 19.3 Tricia x86\_64, kernel 5.3.0-51-generic
+* MacOS Catalina 10.15.4
+
 Java used to run the test is
-* openjdk version "11.0.7" 2020-04-14
+* openjdk version "11.0.7" 2020-04-14 (Linux Mint)
+* java version "11.0.2" 2019-01-15 LTS (Mac OS)
 
 Ruby used to run the test is
 * jruby 9.2.9.0 (2.5.7) 2019-10-30 458ad3e OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on 11.0.7+10-post-Ubuntu-2ubuntu218.04 +jit [linux-x86_64]
-
-OS used to run the test is
-* Linux Mint 19.3 Tricia x86\_64, kernel 5.3.0-51-generic
+* jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 Java HotSpot(TM) 64-Bit Server VM 11.0.2+9-LTS on 11.0.2+9-LTS +jit [darwin-x86_64]
 
 The OpenJFX version used in this integration and tested are:
-* version 11.0.7
-* version 14.0.1
-* version 15
+* version 11.0.2 (LTS Public Version)
+* version 14.0.1 (Latest Release - as of time of writing)
+* version 15 (Early Access Build)
 
 After integrated, the samples/test\_all\_the\_samples.rb was run:
 
-| Demo App                       | version 11.0.7 | version 14.0.1 | version 15 |
+| Demo App                       | version 11.0.2 | version 14.0.1 | version 15 |
 | ------------------------------- | ------------- | -------------- | ---------- |
-| samples/fxml/Demo.rb           |   Success             |   Success             |  Success   |
-| samples/javafx/binding\_app.rb |  Success              |   Success             |  Success   | 
-| samples/javafx/movie\_app.rb   |  Success              |   Success             |  Success   | 
-| samples/javafx/movie\_app.rb   |   No movie is shown but using Oracle Java yield the same result. Media key detected.              |   No movie is shown but using Oracle Java yield the same result. Media key detected.              |  No movie is shown but using Oracle Java yield the same result. Media key detected. | 
-| samples/javafx/tree\_view.rb   |  Success              |   Success             |  Success   | 
+| samples/fxml/Demo.rb           |   Success (Linux & MacOS)   |   Success  (Linux & MacOS)   |  Success  (Linux), halted on Mac (MacOS Note 2)  |
+| samples/javafx/binding\_app.rb |   Success (Linux & MacOS)   |   Success  (Linux & MacOS)   |  Success  (Linux), halted on Mac (MacOS Note 2)  | 
+| samples/javafx/movie\_app.rb   |  Success  (Linux & MacOS)             |   Success  (Linux & MacOS)            |  Success  (Linux), halted on Mac (MacOS Note 2)  | 
+| samples/javafx/movie\_app.rb   |   No movie is shown but using Oracle Java yield the same result. Media key detected.   (Linux & MacOS)            |   No movie is shown but using Oracle Java yield the same result. Media key detected.   (Linux & MacOS)            |  No movie is shown but using Oracle Java yield the same result. Media key detected.   (Linux), halted on Mac (MacOS Note 2) | 
+| samples/javafx/tree\_view.rb   |  Success   (Linux & MacOS)            |   Success     (Linux & MacOS)         |  Success   (Linux), halted on Mac (MacOS Note 2)  | 
 | samples/javafx/image\_view\_with\_multi\_touch.rb  |   Success            |   Success             |  Success   | 
-| samples/javafx/hello\_jrubyfx.rb  |  Success             |   Success             |  Success   | 
-| samples/javafx/analog\_clock.rb  |  Success            |  Success              |  Success   | 
-| samples/javafx/line\_chart.rb  |  Success              |  Success              |  Success   | 
-| samples/javafx/scratchpad.rb   |  Success              | Success               |  Success   | 
-| samples/javafx/table\_app.rb   |  Success              |  Success              |  Success   | 
-| samples/javafx/hello\_devoxx.rb  | Success             |  Success              |  Success   | 
-| samples/contrib/concurrency\_demos/progress\_bar\_task\_demo.rb  |  Success             |    Success            |  Success   | 
-| samples/contrib/fxmlexample/FXMLExample.rb  | Success. But CSS seems not loaded     |    Success. But CSS seems not loaded          |  Success. But CSS seems not loaded   | 
-| samples/contrib/fxmltableview/FXMLTableView.rb  |    Success     |    Success            |  Success   | 
-| samples/contrib/binding\_examples/binding\_demo.rb  |  Success   |    Success            |  Success. Output 3 & 4   | 
+| samples/javafx/hello\_jrubyfx.rb  |  Success (Linux & MacOS)            |   Success    (Linux & MacOS)          |  Success  (Linux), halted on Mac (MacOS Note 2)  | 
+| samples/javafx/analog\_clock.rb  |  Success (Linux & MacOS)           |  Success  (Linux & MacOS)              |  Success (Linux), halted on Mac (MacOS Note 2)  | 
+| samples/javafx/line\_chart.rb  |  Success (Linux & MacOS)             |  Success (Linux & MacOS)              |  Success (Linux), halted on Mac (MacOS Note 2)   | 
+| samples/javafx/scratchpad.rb   |  Success (Linux & MacOS)            | Success (Linux & MacOS)               |  Success (Linux), halted on Mac (MacOS Note 2)   | 
+| samples/javafx/table\_app.rb   |  Success (Linux & MacOS)            |  Success (Linux & MacOS)              |  Succes (Linux), halted on Mac (MacOS Note 2) | 
+| samples/javafx/hello\_devoxx.rb  | Success (Linux & MacOS)             |  Success (Linux & MacOS)              |  Success (Linux), halted on Mac (MacOS Note 2)  | 
+| samples/contrib/concurrency\_demos/progress\_bar\_task\_demo.rb  |  Success (Linux & MacOS)             |    Success (Linux & MacOS)            |   Success (Linux), halted on Mac (MacOS Note 2)  | 
+| samples/contrib/fxmlexample/FXMLExample.rb  | Success (Linux & MacOS)    |    Success (Linux & MacOS)   |   Success (Linux), halted on Mac (MacOS Note 2) | 
+| samples/contrib/fxmltableview/FXMLTableView.rb  |    Success (Linux & MacOS)    |    Success  (Linux & MacOS)          |  Success (Linux), halted on Mac (MacOS Note 2)  | 
+| samples/contrib/binding\_examples/binding\_demo.rb  |  Success (Linux & MacOS)  |    Success (Linux & MacOS)           |  Success (Linux), halted on Mac (MacOS Note 2)  | 
 
 
 Running the ruby files inside tests/
 
-|                   | version 11.0.7 | version 14.0.1 | version 15 |
+|                   | version 11.0.2 | version 14.0.1 | version 15 |
 | ----------------- | -------------- | -------------- | ---------- |
 | bindings.rb       |   Success             |    Success            |  Success   |
 | bug.rb            |   Success             |   Success             |  Success   |
@@ -52,15 +55,19 @@ Running the ruby files inside tests/
 | jsCtrl.rb         |   Failed as error in note 2  |   Failed as error in note 2  |  Failed as error in note 2   |
 | jsNoCtrl.rb       |   Failed as error in note 2  |  Failed as error in note 2   |  Failed as error in note 2   |
 | noCtrl.rb         |   \*similar to note 1        |    \*similar to note 1       |  \*similar to note 1   |
-| jsNoCtrl.rb       |   Failed as error in note 2  |   Failed as error similar to note 2   |  Failed as error similar to note 2   |
-
+| rb.rb             |   Failed as error in note 2  |   Failed as error similar to note 2   |  Failed as error similar to note 2   |
 
 
 \* note 1: Window shown, error shown on console:
-  JIT compiled method for file:/media/chris/vdata/opensource/jrubyfx-openjfx-patch/jrubyfx/tests/ctrl.fxml FAILED with error:
+  JIT compiled method for file:/jrubyfx-openjfx-patch/jrubyfx/tests/ctrl.fxml FAILED with error:
   can't modify frozen NilClass
   org/jruby/RubyKernel.java:2263:in `instance_variable_set'
 
 \* note 2: Exception in thread "JavaFX Application Thread" java.lang.NoClassDefFoundError: javax/script/ScriptEngineFactory
 
 
+MacOS Notes:
+\* Note 1: Sometimes when exiting the window, the following error shall be prompted:
+  Java has been detached already, but someone is still trying to use it at -[GlassViewDelegate dealloc]:/Users/jenkins/workspace/OpenJFX11.0.2-mac/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m:198
+
+\* Note 2: On version 15, shall hit exception "xxx.dylib cannot be opened because the developer cannot be verified. macOS cannot verify that this app is free from malware.". Therefore testing halted.

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -1,0 +1,66 @@
+
+
+# OpenJFX
+
+OpenJFX used was prebuilt library downloaded from [https://gluonhq.com/products/javafx/](https://gluonhq.com/products/javafx/) as that is referred by [https://openjfx.io](https://openjfx.io) download link.
+
+Java used to run the test is
+* openjdk version "11.0.7" 2020-04-14
+
+Ruby used to run the test is
+* jruby 9.2.9.0 (2.5.7) 2019-10-30 458ad3e OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on 11.0.7+10-post-Ubuntu-2ubuntu218.04 +jit [linux-x86_64]
+
+OS used to run the test is
+* Linux Mint 19.3 Tricia x86\_64, kernel 5.3.0-51-generic
+
+The OpenJFX version used in this integration and tested are:
+* version 11.0.7
+* version 14.0.1
+* version 15
+
+After integrated, the samples/test\_all\_the\_samples.rb was run:
+
+| Demo App                       | version 11.0.7 | version 14.0.1 | version 15 |
+| ------------------------------- | ------------- | -------------- | ---------- |
+| samples/fxml/Demo.rb           |   Success             |   Success             |  Success   |
+| samples/javafx/binding\_app.rb |  Success              |   Success             |  Success   | 
+| samples/javafx/movie\_app.rb   |  Success              |   Success             |  Success   | 
+| samples/javafx/movie\_app.rb   |   No movie is shown but using Oracle Java yield the same result. Media key detected.              |   No movie is shown but using Oracle Java yield the same result. Media key detected.              |  No movie is shown but using Oracle Java yield the same result. Media key detected. | 
+| samples/javafx/tree\_view.rb   |  Success              |   Success             |  Success   | 
+| samples/javafx/image\_view\_with\_multi\_touch.rb  |   Success            |   Success             |  Success   | 
+| samples/javafx/hello\_jrubyfx.rb  |  Success             |   Success             |  Success   | 
+| samples/javafx/analog\_clock.rb  |  Success            |  Success              |  Success   | 
+| samples/javafx/line\_chart.rb  |  Success              |  Success              |  Success   | 
+| samples/javafx/scratchpad.rb   |  Success              | Success               |  Success   | 
+| samples/javafx/table\_app.rb   |  Success              |  Success              |  Success   | 
+| samples/javafx/hello\_devoxx.rb  | Success             |  Success              |  Success   | 
+| samples/contrib/concurrency\_demos/progress\_bar\_task\_demo.rb  |  Success             |    Success            |  Success   | 
+| samples/contrib/fxmlexample/FXMLExample.rb  | Success. But CSS seems not loaded     |    Success. But CSS seems not loaded          |  Success. But CSS seems not loaded   | 
+| samples/contrib/fxmltableview/FXMLTableView.rb  |    Success     |    Success            |  Success   | 
+| samples/contrib/binding\_examples/binding\_demo.rb  |  Success   |    Success            |  Success. Output 3 & 4   | 
+
+
+Running the ruby files inside tests/
+
+|                   | version 11.0.7 | version 14.0.1 | version 15 |
+| ----------------- | -------------- | -------------- | ---------- |
+| bindings.rb       |   Success             |    Success            |  Success   |
+| bug.rb            |   Success             |   Success             |  Success   |
+| ctrl.rb           |   \*note 1             |   \*note 1              |  \*note 1   |
+| Hello.rb          |   Success             |   Success             |  Success   |
+| js.rb             |   Failed as error in note 2  |  Failed as error in note 2   |  Failed as error in note 2   |
+| jsCtrl.rb         |   Failed as error in note 2  |   Failed as error in note 2  |  Failed as error in note 2   |
+| jsNoCtrl.rb       |   Failed as error in note 2  |  Failed as error in note 2   |  Failed as error in note 2   |
+| noCtrl.rb         |   \*similar to note 1        |    \*similar to note 1       |  \*similar to note 1   |
+| jsNoCtrl.rb       |   Failed as error in note 2  |   Failed as error similar to note 2   |  Failed as error similar to note 2   |
+
+
+
+\* note 1: Window shown, error shown on console:
+  JIT compiled method for file:/media/chris/vdata/opensource/jrubyfx-openjfx-patch/jrubyfx/tests/ctrl.fxml FAILED with error:
+  can't modify frozen NilClass
+  org/jruby/RubyKernel.java:2263:in `instance_variable_set'
+
+\* note 2: Exception in thread "JavaFX Application Thread" java.lang.NoClassDefFoundError: javax/script/ScriptEngineFactory
+
+

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -10,7 +10,7 @@ It is limited by the pre-built OpenJFX class file is compiled using Java version
 ```ruby
 NameError: cannot link Java class com.sun.javafx.application.PlatformImpl com/sun/javafx/application/PlatformImpl has been compiled by a more recent version of the Java Runtime (class file version 54.0), this version of the Java Runtime only recognizes class file versions up to 52.0
 ```
-Therefore it is only compatible from OpenJDK 10 and above.
+Therefore it is only compatible from JDK/JRE 10 and above.
 
 ## Testing Result
 

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -2,7 +2,11 @@
 
 # OpenJFX
 
-OpenJFX used was prebuilt library downloaded from [https://gluonhq.com/products/javafx/](https://gluonhq.com/products/javafx/) as that is referred by [https://openjfx.io](https://openjfx.io) download link.
+OpenJFX used was pre-built library downloaded from [https://gluonhq.com/products/javafx/](https://gluonhq.com/products/javafx/) as that is referred by [https://openjfx.io](https://openjfx.io) download link.
+
+## Limitation
+
+It is limited by the pre-built OpenJFX class file was compiled by Java 11
 
 The patch is tested on two OSes:
 * Linux Mint 19.3 Tricia x86\_64, kernel 5.3.0-51-generic

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -6,7 +6,7 @@ OpenJFX used was pre-built library downloaded from [https://gluonhq.com/products
 
 ## Limitation
 
-It is limited by the pre-built OpenJFX class file was compiled with Java version 10 (class file version 54.0) proved by the following error message while trying to run it using OpenJDK 1.8:
+It is limited by the pre-built OpenJFX class file is compiled using Java version 10 (class file version 54.0) proved by the following error message while trying to run it using OpenJDK 1.8:
 ```ruby
 NameError: cannot link Java class com.sun.javafx.application.PlatformImpl com/sun/javafx/application/PlatformImpl has been compiled by a more recent version of the Java Runtime (class file version 54.0), this version of the Java Runtime only recognizes class file versions up to 52.0
 ```

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -6,19 +6,25 @@ OpenJFX used was pre-built library downloaded from [https://gluonhq.com/products
 
 ## Limitation
 
-It is limited by the pre-built OpenJFX class file was compiled by Java 11
+It is limited by the pre-built OpenJFX class file was compiled higher then Java 10 (class file version 54.0) proved by the following error message while trying to run it using OpenJDK 1.8:
+```ruby
+NameError: cannot link Java class com.sun.javafx.application.PlatformImpl com/sun/javafx/application/PlatformImpl has been compiled by a more recent version of the Java Runtime (class file version 54.0), this version of the Java Runtime only recognizes class file versions up to 52.0
+```
+Therefore it is only compatible from OpenJDK 10 and above.
+
+## Testing Result
 
 The patch is tested on two OSes:
 * Linux Mint 19.3 Tricia x86\_64, kernel 5.3.0-51-generic
 * MacOS Catalina 10.15.4
 
 Java used to run the test is
-* openjdk version "11.0.7" 2020-04-14 (Linux Mint)
-* java version "11.0.2" 2019-01-15 LTS (Mac OS)
+* (Linux Mint) openjdk version "11.0.7" 2020-04-14 
+* (Mac OS) java version "11.0.2" 2019-01-15 LTS 
 
 Ruby used to run the test is
-* jruby 9.2.9.0 (2.5.7) 2019-10-30 458ad3e OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on 11.0.7+10-post-Ubuntu-2ubuntu218.04 +jit [linux-x86_64]
-* jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 Java HotSpot(TM) 64-Bit Server VM 11.0.2+9-LTS on 11.0.2+9-LTS +jit [darwin-x86_64]
+* (Linux Mint) jruby 9.2.9.0 (2.5.7) 2019-10-30 458ad3e OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on 11.0.7+10-post-Ubuntu-2ubuntu218.04 +jit [linux-x86_64]
+* (Mac OS) jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 Java HotSpot(TM) 64-Bit Server VM 11.0.2+9-LTS on 11.0.2+9-LTS +jit [darwin-x86_64]
 
 The OpenJFX version used in this integration and tested are:
 * version 11.0.2 (LTS Public Version)

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -44,7 +44,7 @@ After integrated, the samples/test\_all\_the\_samples.rb was run:
 | samples/javafx/movie\_app.rb   |  Success  (Linux & MacOS)             |   Success  (Linux & MacOS)            |  Success  (Linux), halted on Mac (MacOS Note 2)  | 
 | samples/javafx/movie\_app.rb   |   No movie is shown but using Oracle Java yield the same result. Media key detected.   (Linux & MacOS)            |   No movie is shown but using Oracle Java yield the same result. Media key detected.   (Linux & MacOS)            |  No movie is shown but using Oracle Java yield the same result. Media key detected.   (Linux), halted on Mac (MacOS Note 2) | 
 | samples/javafx/tree\_view.rb   |  Success   (Linux & MacOS)            |   Success     (Linux & MacOS)         |  Success   (Linux), halted on Mac (MacOS Note 2)  | 
-| samples/javafx/image\_view\_with\_multi\_touch.rb  |   Success            |   Success             |  Success   | 
+| samples/javafx/image\_view\_with\_multi\_touch.rb  |   Success            |   Success             |  Success   (Linux), halted on Mac (MacOS Note 2)   | 
 | samples/javafx/hello\_jrubyfx.rb  |  Success (Linux & MacOS)            |   Success    (Linux & MacOS)          |  Success  (Linux), halted on Mac (MacOS Note 2)  | 
 | samples/javafx/analog\_clock.rb  |  Success (Linux & MacOS)           |  Success  (Linux & MacOS)              |  Success (Linux), halted on Mac (MacOS Note 2)  | 
 | samples/javafx/line\_chart.rb  |  Success (Linux & MacOS)             |  Success (Linux & MacOS)              |  Success (Linux), halted on Mac (MacOS Note 2)   | 
@@ -81,6 +81,7 @@ Running the ruby files inside tests/
 
 
 MacOS Notes:
+
 \* Note 1: Sometimes when exiting the window, the following error shall be prompted:
   Java has been detached already, but someone is still trying to use it at -[GlassViewDelegate dealloc]:/Users/jenkins/workspace/OpenJFX11.0.2-mac/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m:198
 

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -12,6 +12,10 @@ NameError: cannot link Java class com.sun.javafx.application.PlatformImpl com/su
 ```
 Therefore it is only compatible from JDK/JRE 10 and above.
 
+## Changes
+
+The changes only limited to lib/jrubyfx/utils/part\_imports.rb that shall load the OpenJFX library via the environment variable PATH\_TO\_FX as instructed on the [https://openjfx.io](https://openjfx.io/openjfx-docs/#install-javafx) hence if developer followed the instruction, JRubyFX shall be able to work out-of-the-box.
+
 ## Testing Result
 
 The patch is tested on two OSes:

--- a/openjfx-notes.md
+++ b/openjfx-notes.md
@@ -6,7 +6,7 @@ OpenJFX used was pre-built library downloaded from [https://gluonhq.com/products
 
 ## Limitation
 
-It is limited by the pre-built OpenJFX class file was compiled higher then Java 10 (class file version 54.0) proved by the following error message while trying to run it using OpenJDK 1.8:
+It is limited by the pre-built OpenJFX class file was compiled with Java version 10 (class file version 54.0) proved by the following error message while trying to run it using OpenJDK 1.8:
 ```ruby
 NameError: cannot link Java class com.sun.javafx.application.PlatformImpl com/sun/javafx/application/PlatformImpl has been compiled by a more recent version of the Java Runtime (class file version 54.0), this version of the Java Runtime only recognizes class file versions up to 52.0
 ```


### PR DESCRIPTION
The changes mainly to load the OpenJFX libraries into the JRubyFX to allow the JRubyFX use the OpenJFX library on OpenJDK platform directly.

Only limitation is the OpenJFX [https://openjfx.io/](https://openjfx.io/) is compiled using Java 10 therefore only JDK/JRE 10 and above able to use the OpenJFX pre-built binary.

Additional details is located in openjfx-notes.md.